### PR TITLE
Fix: UI crash on plugin install page (#390)

### DIFF
--- a/backend/edgeplugins.go
+++ b/backend/edgeplugins.go
@@ -54,6 +54,9 @@ func (inst *App) EdgeGetPluginsDistribution(connUUID, hostUUID string) *rumodel.
 
 	availablePlugins := make([]rumodel.AvailablePlugin, 0)
 	releases, _, err := githubClient.Repositories.GetReleaseByTag(c, constants.GitHubOwner, constants.FlowFramework, *version)
+	if err != nil {
+		return inst.fail(err)
+	}
 	for _, asset := range releases.Assets {
 		if asset.Name != nil && strings.Contains(*asset.Name, arch) && !strings.Contains(*asset.Name, constants.FlowFramework) {
 			pluginName := strings.Split(*asset.Name, "-")[0]

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 	"github.com/wailsapp/wails/v2/pkg/options"
+	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
 
 //go:embed frontend/dist
@@ -34,10 +35,12 @@ func main() {
 		app.OnQuit()
 	})
 	err = wails.Run(&options.App{
-		Title:       "rubix",
-		Width:       1300,
-		Height:      750,
-		Assets:      assets,
+		Title:  "rubix",
+		Width:  1300,
+		Height: 750,
+		AssetServer: &assetserver.Options{
+			Assets: assets,
+		},
 		StartHidden: false,
 		Menu:        AppMenu,
 		OnStartup:   app.OnStartup,


### PR DESCRIPTION
### Summary

- On the wrong GitHub token it was trying to access the `nil` object's field.